### PR TITLE
Option for stvl to not override StaticLayer's unknown parts 

### DIFF
--- a/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer.hpp
+++ b/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer.hpp
@@ -182,7 +182,8 @@ private:
   rclcpp::Time _last_map_save_time;
   std::string _global_frame;
   double _voxel_size, _voxel_decay;
-  int _combination_method, _mark_threshold;
+  int _mark_threshold;
+  nav2_costmap_2d::CombinationMethod _combination_method;
   volume_grid::GlobalDecayModel _decay_model;
   bool _update_footprint_enabled, _enabled;
   std::vector<geometry_msgs::msg::Point> _transformed_footprint;

--- a/src/spatio_temporal_voxel_layer.cpp
+++ b/src/spatio_temporal_voxel_layer.cpp
@@ -684,11 +684,14 @@ void SpatioTemporalVoxelLayer::updateCosts(
   }
 
   switch (_combination_method) {
-    case 0:
+    case CombinationMethod::Overwrite:
       updateWithOverwrite(master_grid, min_i, min_j, max_i, max_j);
       break;
-    case 1:
+    case CombinationMethod::Max:
       updateWithMax(master_grid, min_i, min_j, max_i, max_j);
+      break;
+    case CombinationMethod::MaxWithoutUnknownOverwrite:
+      updateWithMaxWithoutUnknownOverwrite(master_grid, min_i, min_j, max_i, max_j);
       break;
     default:
       break;

--- a/src/spatio_temporal_voxel_layer.cpp
+++ b/src/spatio_temporal_voxel_layer.cpp
@@ -100,8 +100,10 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
   declareParameter("voxel_size", rclcpp::ParameterValue(0.05));
   node->get_parameter(name_ + ".voxel_size", _voxel_size);
   // 1=takes highest in layers, 0=takes current layer
+  int combination_method_param{};
   declareParameter("combination_method", rclcpp::ParameterValue(1));
-  node->get_parameter(name_ + ".combination_method", _combination_method);
+  node->get_parameter(name_ + ".combination_method", combination_method_param);
+  _combination_method = combination_method_from_int(combination_method_param);
   // number of voxels per vertical needed to have obstacle
   declareParameter("mark_threshold", rclcpp::ParameterValue(0));
   node->get_parameter(name_ + ".mark_threshold", _mark_threshold);
@@ -684,13 +686,13 @@ void SpatioTemporalVoxelLayer::updateCosts(
   }
 
   switch (_combination_method) {
-    case CombinationMethod::Overwrite:
+    case nav2_costmap_2d::CombinationMethod::Overwrite:
       updateWithOverwrite(master_grid, min_i, min_j, max_i, max_j);
       break;
-    case CombinationMethod::Max:
+    case nav2_costmap_2d::CombinationMethod::Max:
       updateWithMax(master_grid, min_i, min_j, max_i, max_j);
       break;
-    case CombinationMethod::MaxWithoutUnknownOverwrite:
+    case nav2_costmap_2d::CombinationMethod::MaxWithoutUnknownOverwrite:
       updateWithMaxWithoutUnknownOverwrite(master_grid, min_i, min_j, max_i, max_j);
       break;
     default:


### PR DESCRIPTION
Add combination method option to use updateWithMaxWithoutUnknownOverwrite.